### PR TITLE
docs(migration): add "Migrate from WebDriverManager" guide

### DIFF
--- a/docs-site/docs/migration/from-selenium-testng.md
+++ b/docs-site/docs/migration/from-selenium-testng.md
@@ -83,7 +83,7 @@ public class LoginTest extends BaseTest {
 }
 ```
 
-- **No `WebDriverManager`.** Modern Selenium (4.6+) bundles **Selenium Manager**, which downloads the right driver binary automatically. Selenium Boot uses it — delete the `.setup()` calls and the dependency.
+- **No `WebDriverManager`.** Modern Selenium (4.6+) bundles **Selenium Manager**, which downloads the right driver binary automatically. Selenium Boot uses it — delete the `.setup()` calls and the dependency. See [Migrate from WebDriverManager](/docs/migration/from-webdrivermanager) for the details.
 - **No `ThreadLocal`.** `DriverManager` isolates the driver per thread, so [parallel runs](/docs/guides/parallel) are safe out of the box.
 - Need the raw driver? It's still there: `getDriver()`.
 

--- a/docs-site/docs/migration/from-webdrivermanager.md
+++ b/docs-site/docs/migration/from-webdrivermanager.md
@@ -1,0 +1,103 @@
+---
+description: "Migrate off WebDriverManager: modern Selenium bundles Selenium Manager, so Selenium Boot resolves driver binaries with zero WebDriverManager code — delete the setup calls and the dependency."
+id: from-webdrivermanager
+title: Migrate from WebDriverManager
+sidebar_label: From WebDriverManager
+sidebar_position: 2
+---
+
+# Migrate from WebDriverManager
+
+If your project calls `WebDriverManager.chromedriver().setup()` (or Boni García's `io.github.bonigarcia:webdrivermanager` in general) to download browser drivers, you can **delete all of it**. Modern Selenium resolves driver binaries itself, and Selenium Boot uses that mechanism out of the box.
+
+:::info Why WebDriverManager existed
+Historically, Selenium needed a matching `chromedriver`/`geckodriver` binary on your machine, and keeping it in sync with the installed browser was painful. WebDriverManager solved that by downloading the right binary at runtime. Since **Selenium 4.6.0** (November 2022), that job moved *into* Selenium itself — see below.
+:::
+
+---
+
+## Selenium Manager makes it built-in
+
+Starting with **Selenium 4.6.0**, Selenium ships **Selenium Manager**: an automatic driver-resolution tool bundled with `selenium-java`. When no driver binary is found, Selenium detects your browser version, downloads the correct driver, and caches it — with **no code and no extra dependency**.
+
+Selenium Boot is built on modern Selenium, so this is already active. You don't call it, configure it, or depend on it directly.
+
+---
+
+## Before / after
+
+**Before** — WebDriverManager as a dependency plus a `setup()` call before every driver you create:
+
+```xml title="pom.xml (remove this)"
+<dependency>
+    <groupId>io.github.bonigarcia</groupId>
+    <artifactId>webdrivermanager</artifactId>
+    <version>5.x</version>
+</dependency>
+```
+
+```java title="DriverFactory.java (remove the setup calls)"
+import io.github.bonigarcia.wdm.WebDriverManager;
+
+WebDriverManager.chromedriver().setup();
+WebDriver driver = new ChromeDriver();
+
+// Firefox
+WebDriverManager.firefoxdriver().setup();
+WebDriver driver = new FirefoxDriver();
+```
+
+**After** — nothing. There is no `setup()` call and no WebDriverManager dependency. With Selenium Boot you don't even create the driver — extend [`BaseTest`](/docs/guides/base-test) and the framework does it:
+
+```java title="LoginTest.java"
+import com.seleniumboot.test.BaseTest;
+import org.testng.annotations.Test;
+
+public class LoginTest extends BaseTest {
+
+    @Test
+    public void loginTest() {
+        open();  // driver already created — binary resolved automatically
+        // ...
+    }
+}
+```
+
+Pick the browser in config, not code:
+
+```yaml title="selenium-boot.yml"
+browser:
+  name: chrome   # chrome | firefox | edge | safari
+```
+
+---
+
+## What gets deleted
+
+| Before | After |
+|---|---|
+| `webdrivermanager` dependency in `pom.xml` / `build.gradle` | ✅ Removed — nothing replaces it |
+| `WebDriverManager.chromedriver().setup()` calls | ✅ Selenium Manager (automatic) |
+| Per-browser `.setup()` branches (Chrome/Firefox/Edge) | ✅ One `browser.name` config line |
+| Pinning driver versions to match browsers | ✅ Selenium Manager matches them for you |
+
+---
+
+## FAQ
+
+**Do I still need WebDriverManager for a specific browser version?**
+No. Selenium Manager detects the installed browser and downloads a matching driver automatically, including for Edge and Firefox.
+
+**What about offline / air-gapped CI?**
+Selenium Manager caches drivers under `~/.cache/selenium`. Warm the cache once (or bake it into your CI image) and subsequent runs need no network. This is the same caching approach WebDriverManager used.
+
+**Can I still point at a specific driver binary?**
+Yes — Selenium honours the standard driver-path system properties (e.g. `webdriver.chrome.driver`) if you set one, so pre-provisioned binaries keep working. You just no longer *need* to.
+
+---
+
+## Next steps
+
+- [Migrate from Selenium + TestNG](/docs/migration/from-selenium-testng) — the full framework migration (driver factory, waits, retry, reporting)
+- [Getting Started](/docs/getting-started) — the 5-minute version
+- [Configuration Reference](/docs/configuration) — the full `selenium-boot.yml`

--- a/docs-site/sidebars.js
+++ b/docs-site/sidebars.js
@@ -10,6 +10,7 @@ const sidebars = {
       label: 'Migration',
       items: [
         'migration/from-selenium-testng',
+        'migration/from-webdrivermanager',
       ],
     },
     {


### PR DESCRIPTION
Closes #10

## What

Adds `docs-site/docs/migration/from-webdrivermanager.md` — a focused migration page showing that **Selenium Manager** (bundled with Selenium since **4.6.0**, Nov 2022) resolves driver binaries automatically, so Selenium Boot needs **zero** WebDriverManager code.

## Contents

- **Before / after** — `webdrivermanager` dependency + `.setup()` calls → nothing (extend `BaseTest`, pick browser in config)
- Note on the Selenium version where Selenium Manager became the default
- "What gets deleted" table
- FAQ covering specific browser versions, offline/air-gapped CI (driver cache), and pointing at a pre-provisioned binary

## Acceptance criteria

- [x] Before/after: WDM setup vs. nothing
- [x] Notes the Selenium version (4.6.0) where Selenium Manager became default
- [x] `description:` frontmatter; linked in the Migration sidebar; restores the cross-link from the Selenium + TestNG guide
- [x] `npm run build` passes (no broken links/anchors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)