### PR TITLE
docs(seo): verify sitemap.xml + tighten generic page titles

### DIFF
--- a/docs-site/docs/accessibility.md
+++ b/docs-site/docs/accessibility.md
@@ -1,7 +1,8 @@
 ---
 description: "Accessibility testing in Selenium: assert WCAG compliance with bundled axe-core in one line, inside your existing Selenium tests, no extra tools."
 id: accessibility
-title: Accessibility Assertions
+title: Selenium Accessibility Testing
+sidebar_label: Accessibility Assertions
 sidebar_position: 17
 ---
 

--- a/docs-site/docs/guides/parallel.md
+++ b/docs-site/docs/guides/parallel.md
@@ -1,7 +1,8 @@
 ---
 description: "Parallel Selenium test execution: set the thread count in selenium-boot.yml and get thread-safe, isolated WebDriver instances automatically."
 id: parallel
-title: Parallel Execution
+title: Selenium Parallel Testing
+sidebar_label: Parallel Execution
 sidebar_position: 5
 ---
 

--- a/docs-site/docs/guides/retry.md
+++ b/docs-site/docs/guides/retry.md
@@ -1,7 +1,8 @@
 ---
 description: "Automatic retry for flaky Selenium tests: Selenium Boot re-runs failures with no IRetryAnalyzer wiring, enabled in a single config line."
 id: retry
-title: Retry
+title: Selenium Retry
+sidebar_label: Retry
 sidebar_position: 4
 ---
 

--- a/docs-site/docs/guides/screenshots.md
+++ b/docs-site/docs/guides/screenshots.md
@@ -1,7 +1,8 @@
 ---
 description: "Automatic screenshots on Selenium test failure, embedded as Base64 in the HTML report, with no external image files or storage to manage."
 id: screenshots
-title: Screenshots
+title: Selenium Screenshots
+sidebar_label: Screenshots
 sidebar_position: 8
 ---
 

--- a/docs-site/docs/guides/self-healing.md
+++ b/docs-site/docs/guides/self-healing.md
@@ -1,7 +1,8 @@
 ---
 description: "Self-healing Selenium locators: when a selector breaks, the framework falls back through id, name, text, and data-testid and flags every heal."
 id: self-healing
-title: Self-Healing Locators
+title: Selenium Self-Healing Locators
+sidebar_label: Self-Healing Locators
 sidebar_position: 10
 ---
 

--- a/docs-site/docs/guides/wait-engine.md
+++ b/docs-site/docs/guides/wait-engine.md
@@ -1,7 +1,8 @@
 ---
 description: "Explicit waits in Selenium without Thread.sleep(): WaitEngine gives fluent, auto-configured waits driven by your selenium-boot.yml timeout."
 id: wait-engine
-title: WaitEngine
+title: Selenium Waits (WaitEngine)
+sidebar_label: WaitEngine
 sidebar_position: 3
 ---
 

--- a/docs-site/docs/reporting/html-report.md
+++ b/docs-site/docs/reporting/html-report.md
@@ -1,7 +1,8 @@
 ---
 description: "Selenium Boot HTML report: a self-contained dashboard with pass-rate gauge, retries, screenshots, flakiness radar, and dark mode, no server needed."
 id: html-report
-title: HTML Report
+title: Selenium HTML Report
+sidebar_label: HTML Report
 sidebar_position: 1
 ---
 

--- a/docs-site/docs/reporting/junit-xml.md
+++ b/docs-site/docs/reporting/junit-xml.md
@@ -1,7 +1,8 @@
 ---
 description: "Selenium Boot emits JUnit-compatible XML that Jenkins, GitHub Actions, and GitLab CI parse natively for standard test result reporting."
 id: junit-xml
-title: JUnit XML
+title: Selenium JUnit XML Report
+sidebar_label: JUnit XML
 sidebar_position: 2
 ---
 

--- a/docs-site/docusaurus.config.js
+++ b/docs-site/docusaurus.config.js
@@ -36,6 +36,13 @@ const config = {
         theme: {
           customCss: require.resolve('./src/css/custom.css'),
         },
+        // Explicit so sitemap generation can't be silently disabled.
+        // Ships with preset-classic; emits build/sitemap.xml listing all pages.
+        sitemap: {
+          changefreq: 'weekly',
+          priority: 0.5,
+          filename: 'sitemap.xml',
+        },
       }),
     ],
   ],


### PR DESCRIPTION
Closes #7

## 1. Sitemap

Confirmed the Docusaurus sitemap plugin (ships with `preset-classic`) is **active and not disabled** — `npm run build` emits `build/sitemap.xml` with **52 `<loc>` entries** covering all doc pages (including the new migration / why / recipes pages). Made the config **explicit** in `docusaurus.config.js` so it can't be silently turned off in a future edit.

## 2. Generic titles → search-friendly

Prefixed a focused set of generic page `<title>`s with "Selenium" for search intent, using the **frontmatter `title` / `sidebar_label` split** so the sidebar labels and visible H1s stay short and clean:

| Page | `<title>` (SEO) | Sidebar / H1 (unchanged) |
|---|---|---|
| retry | Selenium Retry | Retry |
| screenshots | Selenium Screenshots | Screenshots |
| parallel | Selenium Parallel Testing | Parallel Execution |
| wait-engine | Selenium Waits (WaitEngine) | WaitEngine |
| self-healing | Selenium Self-Healing Locators | Self-Healing Locators |
| accessibility | Selenium Accessibility Testing | Accessibility Assertions |
| html-report | Selenium HTML Report | HTML Report |
| junit-xml | Selenium JUnit XML Report | JUnit XML |

## Acceptance criteria

- [x] `sitemap.xml` present in `build/` and lists all doc pages (52 URLs)
- [x] Generic titles prefixed with "Selenium" where it reads naturally
- [x] `npm run build` passes

## Verification

Confirmed in built HTML: `<title>` tags now read `Selenium X | Selenium Boot`, while the page H1 (`Retry`) and sidebar link (`Retry`) stayed short — the split works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)