### PR TITLE
docs(site): add hexagon S-check logo and favicon

### DIFF
--- a/docs-site/docusaurus.config.js
+++ b/docs-site/docusaurus.config.js
@@ -5,7 +5,7 @@ const { themes } = require('prism-react-renderer');
 const config = {
   title: 'Selenium Boot',
   tagline: 'The Spring Boot of Selenium — Playwright-inspired APIs, zero setup, without hiding Selenium',
-  favicon: 'img/logo.svg',
+  favicon: 'img/favicon.svg',
 
   url: 'https://seleniumboot.github.io',
   baseUrl: '/selenium-boot/',

--- a/docs-site/static/img/favicon.svg
+++ b/docs-site/static/img/favicon.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64" role="img" aria-label="Selenium Boot">
+  <defs>
+    <linearGradient id="sbFav" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#4CC15A"/>
+      <stop offset="1" stop-color="#1E5B7B"/>
+    </linearGradient>
+  </defs>
+  <!-- Filled hexagon for contrast at small sizes -->
+  <path d="M32 5 L55.4 18.5 L55.4 45.5 L32 59 L8.6 45.5 L8.6 18.5 Z"
+        fill="url(#sbFav)" stroke="url(#sbFav)" stroke-width="3" stroke-linejoin="round"/>
+  <!-- Bold white check -->
+  <path d="M21 33 L29 41 L44 23"
+        fill="none" stroke="#ffffff" stroke-width="6"
+        stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/docs-site/static/img/logo.svg
+++ b/docs-site/static/img/logo.svg
@@ -1,6 +1,20 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 40" width="40" height="40">
-  <rect width="40" height="40" rx="8" fill="#303f9f"/>
-  <text x="50%" y="55%" dominant-baseline="middle" text-anchor="middle"
-        font-family="'Segoe UI', Arial, sans-serif" font-weight="700"
-        font-size="16" fill="#ffffff" letter-spacing="0.5">SB</text>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64" role="img" aria-label="Selenium Boot">
+  <defs>
+    <linearGradient id="sbGrad" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#4CC15A"/>
+      <stop offset="1" stop-color="#1E5B7B"/>
+    </linearGradient>
+  </defs>
+  <!-- Hexagon container -->
+  <path d="M32 6 L54.5 19 L54.5 45 L32 58 L9.5 45 L9.5 19 Z"
+        fill="none" stroke="url(#sbGrad)" stroke-width="5"
+        stroke-linejoin="round" stroke-linecap="round"/>
+  <!-- Stylized S -->
+  <path d="M31 23 C31 19, 20 19, 20 25 C20 30, 31 30, 31 36 C31 42, 20 42, 20 38"
+        fill="none" stroke="url(#sbGrad)" stroke-width="5"
+        stroke-linecap="round" stroke-linejoin="round"/>
+  <!-- Check mark -->
+  <path d="M34 33 L39 39 L47 26"
+        fill="none" stroke="url(#sbGrad)" stroke-width="5"
+        stroke-linecap="round" stroke-linejoin="round"/>
 </svg>


### PR DESCRIPTION
Replaces the `SB` placeholder logo with a proper brand mark: a hexagon enclosing a stylized **S** and a **checkmark** (passing test), in the green→teal brand gradient — a hand-authored vector interpretation of the shared logo render.

## Files

- **`logo.svg`** — full outline mark for the navbar; the S + check stay legible down to ~28px.
- **`favicon.svg`** — a simplified **solid** hexagon + bold white check, so it reads crisply at 16px (the full S+check is too dense at favicon size).
- **`docusaurus.config.js`** — `favicon` now points at the dedicated `favicon.svg`; the navbar keeps `logo.svg`.

## Verification

Rasterized both marks at real sizes (navbar 32px, favicon 16/32px) on light and dark backgrounds — the navbar mark reads clearly as an "S ✓" hexagon, and the favicon stays legible as a green check-badge at 16px. `npm run build` passes and both assets ship to `build/img/`.

## Notes

- Self-contained SVGs (inline gradient, no external refs).
- This is a **vector interpretation**, not pixel-identical to the PNG render shared. The designer's exact SVG can later drop into the same file paths with no config change.
- Tagline / "AI POWERED" wording and the Selenium-trademark palette question (raised in discussion) are intentionally **out of scope** here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)