### PR TITLE
docs: serve at docs.seleniumboot.com (custom domain)

### DIFF
--- a/docs-site/docusaurus.config.js
+++ b/docs-site/docusaurus.config.js
@@ -7,8 +7,8 @@ const config = {
   tagline: 'The Spring Boot of Selenium — Playwright-inspired APIs, zero setup, without hiding Selenium',
   favicon: 'img/favicon.svg',
 
-  url: 'https://seleniumboot.github.io',
-  baseUrl: '/selenium-boot/',
+  url: 'https://docs.seleniumboot.com',
+  baseUrl: '/',
 
   organizationName: 'seleniumboot',
   projectName: 'selenium-boot',

--- a/docs-site/static/CNAME
+++ b/docs-site/static/CNAME
@@ -1,0 +1,1 @@
+docs.seleniumboot.com


### PR DESCRIPTION
Points the docs site at **docs.seleniumboot.com** as a GitHub Pages custom domain. Docs continue to build & deploy on GitHub Pages unchanged.

## Changes
- `docusaurus.config.js`: `url` → https://docs.seleniumboot.com, `baseUrl` → `/`
- add `docs-site/static/CNAME` (keeps the custom domain across deploys)

## Merge coordination (do NOT merge until DNS is ready)
1. In MilesWeb: delete the `docs.seleniumboot.com` **subdomain** vhost.
2. In DNS (mydnsvault): add `CNAME docs → seleniumboot.github.io` (remove any `A` for `docs`).
3. Merge this PR → docs redeploy → GitHub provisions the HTTPS cert for the domain.

The old `seleniumboot.github.io/selenium-boot/` URL auto-redirects to the new domain after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)