### PR TITLE
chore: fix stale test count, javadoc escape, and baseline gitignore guard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,11 @@ docs-site/.docusaurus/
 docs-site/build/
 
 articles/*
+
+*.log
+*.env
+
+### Test-generated visual baselines ###
+# VisualAssert tests write throwaway timestamped baseline PNGs here during runs.
+# Guard against a failed cleanup dirtying the tree or committing throwaway images.
+src/test/resources/baselines/*.png

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,7 +85,7 @@ Classes/methods annotated `@SeleniumBootApi` are the stable public surface. Avoi
 
 ## Tests
 
-Unit tests are in `src/test/java/com/seleniumboot/unit/` (12 test classes). They use **TestNG + Mockito**. Tests mock Selenium/browser interactions — no real browser is required to run the test suite.
+Unit tests are in `src/test/java/com/seleniumboot/unit/` (39 test classes, 480 tests). They use **TestNG + Mockito**. Tests mock Selenium/browser interactions — no real browser is required to run the test suite.
 
 ## Configuration Reference
 

--- a/src/main/java/com/seleniumboot/driver/DriverManager.java
+++ b/src/main/java/com/seleniumboot/driver/DriverManager.java
@@ -14,7 +14,7 @@ import java.util.concurrent.TimeUnit;
  * Rules:
  * <li>One WebDriver per thread</li>
  * <li>ThreadLocal ownership</li>
- * <li>Framework-managed creation & destruction only</li>
+ * <li>Framework-managed creation &amp; destruction only</li>
  * <li>Session limit is enforced with a blocking Semaphore — tests wait for a slot
  *     rather than failing fast, preventing spurious failures under parallel load</li>
  */


### PR DESCRIPTION
Follow-up cleanups surfaced by a release-readiness `mvn clean verify` run of v3.1.1 (480 tests, 0 failures — all green). None block a release; these are hygiene.

## Changes
- **CLAUDE.md** — corrected the stale "12 test classes" to "39 test classes, 480 tests" so the doc stops under-reporting coverage.
- **DriverManager.java** — escaped an unescaped `&` as `&amp;` in a javadoc `<li>` (cleared the javadoc build warning; jar built fine regardless).
- **.gitignore** — added `src/test/resources/baselines/*.png` guard. VisualAssert tests write throwaway timestamped baseline PNGs there during runs; this prevents a failed cleanup from dirtying the tree or accidentally committing throwaway images.

🤖 Generated with [Claude Code](https://claude.com/claude-code)