### PR TITLE
release: v3.2.0 — WaitEngine attributeToBe, urlMatches, textMatches

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -32,7 +32,7 @@ body:
     id: sb-version
     attributes:
       label: Selenium Boot version
-      placeholder: "3.1.1"
+      placeholder: "3.2.0"
     validations:
       required: true
   - type: input

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ---
 
+### v3.2.0 — 2026-07-18
+
+- **Three new `WaitEngine` conditions**, consistent with the existing `waitFor*` naming:
+  - `waitForAttribute(By, attribute, value)` — waits for an exact attribute match (use the existing `waitForAttributeContains` for a substring match)
+  - `waitForUrlMatches(String regex)` — waits for the current URL to match a regular expression (use the existing `waitForUrlContains` for a substring match)
+  - `waitForTextMatches(By, String regex)` — waits for an element's visible text to match a regular expression
+  - Purely additive to the `@SeleniumBootApi` surface — no breaking changes. (Closes #12)
+
 ### v3.1.1 — 2026-06-26
 
 - **Per-engine report output directory** — the metrics JSON, HTML report, and metrics history now honor the `seleniumboot.reports.dir` system property (the same switch already used for the JUnit XML report), defaulting to `target` as before. This fixes the HTML report being **overwritten** when two test engines run in one build — e.g. a TestNG suite (Surefire) and JUnit 5 tests (Failsafe): point each engine's run at its own directory (`-Dseleniumboot.reports.dir=target/junit5`) and each produces a self-contained report instead of the last one clobbering the first.

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Add to your `pom.xml`:
 <dependency>
     <groupId>io.github.seleniumboot</groupId>
     <artifactId>selenium-boot</artifactId>
-    <version>3.1.1</version>
+    <version>3.2.0</version>
 </dependency>
 ```
 
@@ -652,7 +652,7 @@ ci:
 
 ## Project Status
 
-**Current release: v3.1.1** — per-engine report output dir (`seleniumboot.reports.dir`), fixing report overwrites when TestNG + JUnit 5 run in one build.
+**Current release: v3.2.0** — three new `WaitEngine` conditions: `waitForAttribute` (exact-match attribute), `waitForUrlMatches`, and `waitForTextMatches` (regex).
 
 See the full version history in **[CHANGELOG.md](CHANGELOG.md)**.
 

--- a/docs-site/docs/changelog.md
+++ b/docs-site/docs/changelog.md
@@ -11,6 +11,17 @@ All notable changes to Selenium Boot are documented here.
 
 ---
 
+## [3.2.0] — 2026-07-18
+
+### Added
+- **Three new `WaitEngine` conditions**, consistent with the existing `waitFor*` naming:
+  - `waitForAttribute(By, attribute, value)` — waits for an exact attribute match (see `waitForAttributeContains` for a substring match).
+  - `waitForUrlMatches(String regex)` — waits for the current URL to match a regular expression (see `waitForUrlContains` for a substring match).
+  - `waitForTextMatches(By, String regex)` — waits for an element's visible text to match a regular expression.
+  - Purely additive to the `@SeleniumBootApi` surface — no breaking changes.
+
+---
+
 ## [3.1.1] — 2026-06-26
 
 ### Fixed

--- a/docs-site/docs/getting-started.md
+++ b/docs-site/docs/getting-started.md
@@ -35,7 +35,7 @@ No WebDriver binaries required — Selenium Manager handles browser driver downl
 <dependency>
     <groupId>io.github.seleniumboot</groupId>
     <artifactId>selenium-boot</artifactId>
-    <version>3.1.1</version>
+    <version>3.2.0</version>
 </dependency>
 ```
 
@@ -44,7 +44,7 @@ No WebDriver binaries required — Selenium Manager handles browser driver downl
 
 ```groovy title="build.gradle"
 dependencies {
-    testImplementation 'io.github.seleniumboot:selenium-boot:3.1.1'
+    testImplementation 'io.github.seleniumboot:selenium-boot:3.2.0'
 }
 
 test {
@@ -58,7 +58,7 @@ test {
 
 ```kotlin title="build.gradle.kts"
 dependencies {
-    testImplementation("io.github.seleniumboot:selenium-boot:3.1.1")
+    testImplementation("io.github.seleniumboot:selenium-boot:3.2.0")
 }
 
 tasks.test {

--- a/docs-site/docs/junit5.md
+++ b/docs-site/docs/junit5.md
@@ -17,7 +17,7 @@ Selenium Boot supports both **TestNG** (built-in) and **JUnit 5** (opt-in). The 
 <dependency>
     <groupId>io.github.seleniumboot</groupId>
     <artifactId>selenium-boot</artifactId>
-    <version>3.1.1</version>
+    <version>3.2.0</version>
 </dependency>
 
 <dependency>

--- a/docs-site/docs/migration/from-selenium-testng.md
+++ b/docs-site/docs/migration/from-selenium-testng.md
@@ -26,7 +26,7 @@ Remove your Selenium, WebDriverManager, and reporting dependencies and add one:
 <dependency>
     <groupId>io.github.seleniumboot</groupId>
     <artifactId>selenium-boot</artifactId>
-    <version>3.1.1</version>
+    <version>3.2.0</version>
 </dependency>
 ```
 

--- a/docs-site/src/pages/index.js
+++ b/docs-site/src/pages/index.js
@@ -241,7 +241,7 @@ export default function Home() {
                 code={`<dependency>
   <groupId>io.github.seleniumboot</groupId>
   <artifactId>selenium-boot</artifactId>
-  <version>3.1.1</version>
+  <version>3.2.0</version>
 </dependency>`}
               />
             </div>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.github.seleniumboot</groupId>
     <artifactId>selenium-boot</artifactId>
-    <version>3.1.1</version>
+    <version>3.2.0</version>
     <packaging>jar</packaging>
 
     <name>Selenium Boot</name>


### PR DESCRIPTION
## Summary

Version bump for v3.2.0, covering the three new `WaitEngine` conditions shipped in #21 (`ee05c68`):

- `waitForAttribute(By, attribute, value)` — exact attribute match (vs. the existing `waitForAttributeContains` substring match)
- `waitForUrlMatches(String regex)` — regex URL match (vs. the existing `waitForUrlContains` substring match)
- `waitForTextMatches(By, String regex)` — regex match on an element's visible text

All purely additive to the `@SeleniumBootApi` surface — no breaking changes. Docs for these were already updated in `docs-site/docs/guides/wait-engine.md` as part of #21, so this PR does not touch that file.

## Scope

Every version reference named in the `CLAUDE.md` release checklist table, plus one stale reference the table doesn't list (`docs-site/docs/migration/from-selenium-testng.md`) and the bug-report issue template's version placeholder — found via a repo-wide grep for `3.1.1`:

- `pom.xml`
- `README.md` (dependency snippet + "Current release" line)
- `CHANGELOG.md` (new v3.2.0 entry)
- `docs-site/docs/getting-started.md` (Maven + Gradle Groovy + Gradle Kotlin snippets)
- `docs-site/docs/junit5.md`
- `docs-site/docs/changelog.md` (new v3.2.0 entry)
- `docs-site/src/pages/index.js`
- `docs-site/docs/migration/from-selenium-testng.md`
- `.github/ISSUE_TEMPLATE/bug_report.yml`

**Deliberately excluded:** `PLAN.md` doesn't exist in this repo (stale checklist reference, tracked separately — not fixed here to keep this diff clean) and the marketing site's `LATEST_VERSION` (`seleniumboot-website/src/data/content.ts`). Per checklist step 7, the website bump happens *after* the artifact is live on Maven Central, so it isn't part of this PR — bumping it now would advertise a `pom.xml` snippet that doesn't resolve yet.

## Test plan

- [x] `mvn clean verify` passes — 480/480 tests, 0 failures, 0 errors, 0 skipped
- [ ] Maintainer merges this PR
- [ ] Tag `v3.2.0` on the merged commit, push tag
- [ ] `gh release create v3.2.0 ...`
- [ ] `mvn deploy` to Maven Central (manual, maintainer-run)
- [ ] Bump `LATEST_VERSION` in `seleniumboot-website` post-Central and deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)