### PR TITLE
docs: add robots.txt for docs.seleniumboot.com

### DIFF
--- a/docs-site/static/robots.txt
+++ b/docs-site/static/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://docs.seleniumboot.com/sitemap.xml


### PR DESCRIPTION
## What

Adds `docs-site/static/robots.txt`, which Docusaurus copies verbatim to the domain root on build.

## Why

`https://docs.seleniumboot.com/robots.txt` currently returns **404**. That is not blocking indexing — crawlers treat an absent robots.txt as allow-all — but it means the docs sitemap is only discoverable through a direct Search Console submission, not to any crawler arriving on its own.

This declares allow-all plus `Sitemap: https://docs.seleniumboot.com/sitemap.xml`, so the 53 doc URLs are self-describing.

## Verified

- Live sitemap is correct: 53 URLs, all on `docs.seleniumboot.com` (no stray `seleniumboot.github.io` entries).
- No `noindex` anywhere in the Docusaurus config or output.

Merging to `master` triggers the Pages deploy that makes the file live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)