### PR TITLE
docs: instrument docs.seleniumboot.com with GoatCounter

### DIFF
--- a/docs-site/docusaurus.config.js
+++ b/docs-site/docusaurus.config.js
@@ -18,6 +18,30 @@ const config = {
   onBrokenLinks: 'throw',
   onBrokenMarkdownLinks: 'warn',
 
+  // GoatCounter — cookieless, no personal data, no consent banner (same account as
+  // seleniumboot.com, see the site's /privacy page).
+  //
+  // Docs and the marketing site report into ONE GoatCounter site, so raw paths would
+  // collide: the apex homepage and the docs homepage both count as "/". The first
+  // script namespaces every docs hit under "/docs-site/..." so the two hostnames stay
+  // separable in the dashboard. Order matters — settings must run before count.js.
+  headTags: [
+    {
+      tagName: 'script',
+      attributes: { type: 'text/javascript' },
+      innerHTML:
+        "window.goatcounter={path:function(p){return '/docs-site'+p;}};",
+    },
+    {
+      tagName: 'script',
+      attributes: {
+        async: 'true',
+        src: 'https://gc.zgo.at/count.js',
+        'data-goatcounter': 'https://seleniumboot.goatcounter.com/count',
+      },
+    },
+  ],
+
   i18n: {
     defaultLocale: 'en',
     locales: ['en'],


### PR DESCRIPTION
Closes **P1-9**.

## Why

`docs-site/docusaurus.config.js` had **no analytics of any kind** — no `scripts`, no `headTags`, nothing. All 53 doc pages were invisible, so the entire quickstart funnel was unmeasured, and any CTA landing on docs (including the dev.to post's only link) recorded no referral.

This is more urgent than when it was filed: the live Show HN points at the GitHub repo, and the repo README's primary links go to `docs.seleniumboot.com`. Any traffic it sends lands on the one surface that records nothing.

## What

Same GoatCounter account as `seleniumboot.com` — cookieless, no personal data, no consent banner needed.

**One wrinkle worth calling out:** docs and the marketing site report into a *single* GoatCounter site, so raw paths collide — the apex homepage and the docs homepage would both count as `/`, corrupting the homepage number that gets watched most. An inline settings script namespaces every docs hit under `/docs-site/...` so the two hostnames stay separable. Head-tag ordering guarantees it runs before `count.js`.

## Verification

- `npm run build` succeeds
- **All 54 generated HTML pages** carry both the namespacing script and the `count.js` tag (53 docs + index)
- Spot-checked a deep page (`build/docs/getting-started.html`) — correct endpoint attribute
- Confirmed the minifier preserves the path function: `window.goatcounter={path:function(t){return"/docs-site"+t}}`

## After merge

Deploys via the existing `docs-site/**` → GitHub Pages path. Worth confirming hits appear in GoatCounter under `/docs-site/*` once it's live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)